### PR TITLE
Let function selection drive question step in wizard

### DIFF
--- a/src/com/yetanalytics/dave/func.cljc
+++ b/src/com/yetanalytics/dave/func.cljc
@@ -597,6 +597,11 @@
             (s/every
              keyword?)))
 
+;; Funcs have a default question text that can be suggested to the user
+(s/def ::question-text-default
+  (s/and string?
+         not-empty))
+
 (def registry
   "A map of function keyword to implementation. Each function is a map
   containing:
@@ -610,14 +615,16 @@
     :function (init (map->SuccessTimeline {})) ;; success-timeline
     :fspec (s/get-spec `success-timeline)
     :args-default {}
-    :args-enum {}}
+    :args-enum {}
+    :question-text-default "When do learners do their best work?"}
    ::difficult-questions
    {:title "Difficult Questions"
     :doc "Plots interaction activity ids against the number of failed attempts for that activity."
     :function (init (map->DifficultQuestions {}))
     :fspec (s/get-spec `difficult-questions)
     :args-default {}
-    :args-enum {}}
+    :args-enum {}
+    :question-text-default "What activities are most difficult?"}
    ::completion-rate
    {:title "Completion Rate"
     :doc "Plots activity ids against the rate of completions per given time unit."
@@ -630,7 +637,9 @@
                              :day
                              :week
                              :month
-                             :year}}}
+                             :year}}
+    :question-text-default
+    "What activities are completed the most?"}
    ::followed-recommendations
    {:title "Followed Recommendations"
     :doc "Buckets statements into periods (time ranges) by statement timestamp. Within each bucket, counts the number of recommendations, launches and follows expressed."
@@ -643,7 +652,15 @@
                              :day
                              :week
                              :month
-                             :year}}}})
+                             :year}}
+    :question-text-default
+    "How often are recommendations followed?"}})
+
+;; Keep a set of the default text so we know to only replace if it isn't custom
+(def question-text-defaults
+  (into #{}
+        (map :question-text-default
+             (vals registry))))
 
 (def func-spec
   (s/with-gen
@@ -651,7 +668,8 @@
                      ::fspec
                      ::title
                      ::args-default
-                     ::args-enum]
+                     ::args-enum
+                     ::question-text-default]
             :opt-un [::doc])
     (fn []
       (sgen/elements (vals registry)))))

--- a/src/com/yetanalytics/dave/ui/views/wizard.cljs
+++ b/src/com/yetanalytics/dave/ui/views/wizard.cljs
@@ -202,7 +202,8 @@
   []
   (let [{:keys [workbook-id question-id]}
         @(subscribe [:com.yetanalytics.dave.ui.app.wizard/wizard])]
-    (into [:div.args]
+    (into [:div.args
+           [wizard-field :text "Question Text"]]
           (for [[k enum] @(subscribe [:wizard.question.function.info/args-enum])
                 ]
             [select/select
@@ -212,7 +213,7 @@
                               {:label (name v)
                                :value (name v)}))
              :selected (if-let [sel @(subscribe [:wizard.form/field (conj [:function :args]
-                                                                            k)])]
+                                                                          k)])]
                          (name sel)
                          "")
              :handler #(-> %
@@ -224,14 +225,13 @@
 (defn step-3-form
   []
   [:div.wizard-form
-   [wizard-field :text "Question Text"]
-   [step-3-form-function-info]
-   [step-3-form-function-args]
    [:button.majorbutton
     {:on-click #(dispatch [:wizard.question.function/offer-picker])}
     (if-not @(subscribe [:wizard.form/field :function])
       "Choose A Function"
-      "Choose Another Function")]])
+      "Choose Another Function")]
+   [step-3-form-function-info]
+   [step-3-form-function-args]])
 
 (defn step-3-problems
   []


### PR DESCRIPTION
Previously, we prompted the user to enter question text and then select a function. Per review with stakeholders, function selection should be the primary action, and functions should carry a default textual question when selected.

If a user has entered a question that is not in the predefined set of default questions carried on functions, and it is not empty, it will not be changed in this way.