### PR TITLE
Standardize new/edit forms

### DIFF
--- a/src/com/yetanalytics/dave/ui/app/crud.cljs
+++ b/src/com/yetanalytics/dave/ui/app/crud.cljs
@@ -52,6 +52,7 @@
                                re-index))]
      {:db new-db
       :dispatch [:db/save]
+      :com.yetanalytics.dave.ui.app.nav/nav-path! db-path
       :notify/snackbar
       {:message "Success"}})))
 

--- a/src/com/yetanalytics/dave/ui/app/crud.cljs
+++ b/src/com/yetanalytics/dave/ui/app/crud.cljs
@@ -52,7 +52,6 @@
                                re-index))]
      {:db new-db
       :dispatch [:db/save]
-      :com.yetanalytics.dave.ui.app.nav/nav-path! db-path
       :notify/snackbar
       {:message "Success"}})))
 

--- a/src/com/yetanalytics/dave/ui/app/workbook.cljs
+++ b/src/com/yetanalytics/dave/ui/app/workbook.cljs
@@ -18,6 +18,7 @@
                 :label "Description"}]
       :form {}}]}))
 
+;; Only run after the new workbook action, NOT in the wiz
 (re-frame/reg-event-fx
  :workbook/create
  (fn [{:keys [db] :as ctx} [_ form-map]]
@@ -25,11 +26,6 @@
           :as new-workbook} (merge form-map
                                    {:id (random-uuid)
                                     :index 0
-                                    ;; TODO: remove the auto test dataset
-                                    :data {:title "test dataset"
-                                           :type :com.yetanalytics.dave.workbook.data/file
-                                           :uri "/data/dave/ds.json"
-                                           :built-in? true}
                                     :questions {}})]
      (if-let [spec-error (s/explain-data workbook/workbook-spec
                                          new-workbook)]
@@ -38,11 +34,21 @@
         ;; TODO: human readable spec errors
         {:message "Invalid Workbook"}}
        ;; it's valid, dismiss the dialog and pass it off to CRUD
+       ;; the after-create action will nav to it and open the picker
        {:dispatch-n [[:dialog/dismiss]
                      [:crud/create!
                       new-workbook
-                      id
-                      ]]}))))
+                      id]
+                     [:workbook/after-create
+                      id]]}))))
+
+(re-frame/reg-event-fx
+ :workbook/after-create
+ (fn [_ [_ workbook-id]]
+   {:com.yetanalytics.dave.ui.app.nav/nav-path! [:workbooks
+                                                 workbook-id]
+    :dispatch [:workbook.data/offer-picker
+               workbook-id]}))
 
 (re-frame/reg-event-fx
  :workbook/edit

--- a/src/com/yetanalytics/dave/ui/app/workbook.cljs
+++ b/src/com/yetanalytics/dave/ui/app/workbook.cljs
@@ -65,7 +65,12 @@
                   :label "Title"}
                  {:key :description
                   :label "Description"}]
-        :form (select-keys workbook [:title :description])}]})))
+        :form (select-keys workbook [:title :description])
+        :additional-actions
+        [{:label "Select Dataset"
+          :mdc-dialog-action "cancel"
+          :dispatch [:workbook.data/offer-picker
+                     workbook-id]}]}]})))
 
 (re-frame/reg-event-fx
  :workbook/update

--- a/src/com/yetanalytics/dave/ui/app/workbook/question.cljs
+++ b/src/com/yetanalytics/dave/ui/app/workbook/question.cljs
@@ -34,8 +34,22 @@
                      [:crud/create!
                       new-question
                       workbook-id
-                      id
-                      ]]}))))
+                      id]
+                     [:workbook.question/after-create
+                      workbook-id
+                      id]]}))))
+
+(re-frame/reg-event-fx
+ :workbook.question/after-create
+ (fn [_ [_ workbook-id
+         question-id]]
+   {:com.yetanalytics.dave.ui.app.nav/nav-path! [:workbooks
+                                                 workbook-id
+                                                 :questions
+                                                 question-id]
+    :dispatch [:workbook.question.function/offer-picker
+               workbook-id
+               question-id]}))
 
 (re-frame/reg-event-fx
  :workbook.question/edit

--- a/src/com/yetanalytics/dave/ui/app/workbook/question.cljs
+++ b/src/com/yetanalytics/dave/ui/app/workbook/question.cljs
@@ -69,7 +69,13 @@
                         question-id]
         :fields [{:key :text
                   :label "Question Text"}]
-        :form (select-keys question [:text])}]})))
+        :form (select-keys question [:text])
+        :additional-actions
+        [{:label "Select Function"
+          :mdc-dialog-action "cancel"
+          :dispatch [:workbook.question.function/offer-picker
+                     workbook-id
+                     question-id]}]}]})))
 
 (re-frame/reg-event-fx
  :workbook.question/update

--- a/src/com/yetanalytics/dave/ui/app/workbook/question/visualization.cljs
+++ b/src/com/yetanalytics/dave/ui/app/workbook/question/visualization.cljs
@@ -80,7 +80,14 @@
                         workbook-id question-id visualization-id]
         :fields [{:key :title
                   :label "Title"}]
-        :form (select-keys visualization [:title])}]})))
+        :form (select-keys visualization [:title])
+        :additional-actions
+        [{:label "Select Visualization"
+          :mdc-dialog-action "cancel"
+          :dispatch [:workbook.question.visualization/offer-picker
+                     workbook-id
+                     question-id
+                     visualization-id]}]}]})))
 
 (re-frame/reg-event-fx
  :workbook.question.visualization/update

--- a/src/com/yetanalytics/dave/ui/app/workbook/question/visualization.cljs
+++ b/src/com/yetanalytics/dave/ui/app/workbook/question/visualization.cljs
@@ -35,7 +35,28 @@
                       workbook-id
                       question-id
                       id
-                      ]]}))))
+                      ]
+                     [:workbook.question.visualization/after-create
+                      workbook-id
+                      question-id
+                      id]]}))))
+
+(re-frame/reg-event-fx
+ :workbook.question.visualization/after-create
+ (fn [_ [_
+         workbook-id
+         question-id
+         vis-id]]
+   {:com.yetanalytics.dave.ui.app.nav/nav-path! [:workbooks
+                                                 workbook-id
+                                                 :questions
+                                                 question-id
+                                                 :visualizations
+                                                 vis-id]
+    :dispatch [:workbook.question.visualization/offer-picker
+               workbook-id
+               question-id
+               vis-id]}))
 
 ;; Handlers
 (re-frame/reg-event-fx

--- a/src/com/yetanalytics/dave/ui/views/dialog.cljs
+++ b/src/com/yetanalytics/dave/ui/views/dialog.cljs
@@ -41,17 +41,13 @@
                     ;; re-framey way.
                     :tab-index 0}
                    "Cancel"]]
-                 (for [{:keys [label
-                               mdc-dialog-action
-                               on-click
-                               disabled?]} actions]
+                 (for [[idx {:keys [label
+                                    mdc-dialog-action
+                                    on-click
+                                    disabled?]}] (map-indexed vector actions)]
                    [:button.mdc-button.mdc-dialog__button
                     (cond-> {:on-click on-click
-                             #_(fn [e]
-                                         (.preventDefault e)
-                                         (.close @dialog-ref)
-                                         (on-click)
-                                 e)}
+                             :tab-index (inc idx)}
                       disabled?
                       (assoc :disabled true)
                       mdc-dialog-action
@@ -94,9 +90,15 @@
                           (for [field @(subscribe [:dialog.form/fields])]
                             [form-field-input field]))
            :actions
-           [{:label "Save"
-             ;; :mdc-dialog-action "save"
-             :on-click #(dispatch [:dialog.form/save])}]}])
+           (into []
+                 (concat
+                  (for [{dispatch-v :dispatch
+                         :keys [label] :as action}
+                        @(subscribe [:dialog/additional-actions])]
+                    (merge action {:on-click #(dispatch dispatch-v)}))
+                  [{:label "Save"
+                    ;; :mdc-dialog-action "save"
+                    :on-click #(dispatch [:dialog.form/save])}]))}])
 
 (defn dialog-wizard
   "Dialog for the dave workbook creation wizard"

--- a/src/com/yetanalytics/dave/ui/views/workbook/data.cljs
+++ b/src/com/yetanalytics/dave/ui/views/workbook/data.cljs
@@ -54,6 +54,5 @@
        :com.yetanalytics.dave.workbook.data/file "insert_drive_file"
        :com.yetanalytics.dave.workbook.data/lrs "storage")]
     @(subscribe [:workbook.data/title ?workbook-id])]
-   [change-button ?workbook-id]
    [details ?workbook-id]
    [errors ?workbook-id]])

--- a/src/com/yetanalytics/dave/ui/views/workbook/question/func.cljs
+++ b/src/com/yetanalytics/dave/ui/views/workbook/question/func.cljs
@@ -31,7 +31,7 @@
     [:img.title-img {:src "img/lambda.svg"}]
     "Function: " @(subscribe [:workbook.question.function.func/title
                               workbook-id question-id])
-    [:button.minorbutton
+    #_[:button.minorbutton
      {:on-click #(dispatch [:workbook.question.function/offer-picker
                             workbook-id question-id])}
      "Change Function"]]

--- a/src/com/yetanalytics/dave/ui/views/workbook/question/visualization.cljs
+++ b/src/com/yetanalytics/dave/ui/views/workbook/question/visualization.cljs
@@ -50,7 +50,7 @@
      [:div ;; inner
       [:div.splash
        [:h2 title]
-       [:button.majorbutton
+       #_[:button.majorbutton
         {:on-click #(dispatch [:workbook.question.visualization/offer-picker
                                workbook-id question-id id])}
         "Change Visualization"]


### PR DESCRIPTION
For the three Dave objects that have a single-child relationship, ie:
* Workbook - Dataset
* Question - Function
* Visualization - Vis

We've been separating the dialog to edit the parent from the button that launches the picker overlay to select the child. This was confusing, as picking a child is really editing the parent

This PR enhances the dialog system to allow additional, arbitrary dialog actions. Using these, we group the button to select a child with the edit form for the parent. The standalone child selection buttons have been removed.

For new objects, the behavior is a little different. The form will require the user to enter required fields for the object but then, once they click save, it will navigate to the object and open the picker.