### PR TITLE
Vis Layout

### DIFF
--- a/resources/dave/ui/sass/debug.scss
+++ b/resources/dave/ui/sass/debug.scss
@@ -2,3 +2,13 @@
   /* don't let the position be fixed, we want it to sit over the normal bar */
   position: unset;
 }
+
+
+/* Put a blue border on vega containers */
+// .dave-vega-container {
+//   border: 1px solid blue;
+// }
+
+// .dave-vega-container > svg {
+//   border: 1px solid red;
+// }

--- a/resources/dave/ui/sass/picker.scss
+++ b/resources/dave/ui/sass/picker.scss
@@ -50,6 +50,9 @@ div.picker {
       > div.dave-vega-container{
         min-height: 150px;
         min-width: 170px;
+        > svg {
+          max-height: 150px;
+        }
       }
       > .selectorspan{
         background-color: #d9d9d9;

--- a/resources/dave/ui/sass/vega.scss
+++ b/resources/dave/ui/sass/vega.scss
@@ -2,5 +2,8 @@
 
 div.dave-vega-container {
   min-height: 300px;
-  min-width: 300px;
+  > svg {
+    width: 100%;
+    max-height: 80vh;
+  }
 }

--- a/src/com/yetanalytics/dave/ui/views/vega.cljs
+++ b/src/com/yetanalytics/dave/ui/views/vega.cljs
@@ -226,14 +226,21 @@
         el (r/dom-node this)
         el-width (.-offsetWidth el)
         el-height (.-offsetHeight el)
+        {spec-width :width
+         spec-height :height} spec
+        [width
+         height] (if (= spec-width spec-height)
+                   [spec-width
+                    spec-height]
+                   [el-width
+                    el-height])
         runtime (.parse js/vega (clj->js spec))
         chart (-> (js/vega.View. runtime)
                   (.logLevel (s/conform ::log-level
                                         log-level))
-                  (.width (-> el-width
-                              (* 0.9)
-                              int))
-                  (.height el-height)
+
+                  (.width width)
+                  (.height height)
                   (.renderer renderer)
                   (.initialize el)
                   (cond-> hover? .hover))]

--- a/src/com/yetanalytics/dave/ui/views/workbook/question.cljs
+++ b/src/com/yetanalytics/dave/ui/views/workbook/question.cljs
@@ -61,9 +61,7 @@
      [visualization/display
       workbook-id id
       @(subscribe [:workbook.question/first-visualization-id
-                   workbook-id id])
-      :vega-override {:height 200
-                      :width 200}])
+                   workbook-id id])])
    [:a {:href (str "#/workbooks/" @(subscribe [:nav/focus-id])
                    "/questions/" id)}
     "Select"]])

--- a/src/com/yetanalytics/dave/ui/views/workbook/question/visualization.cljs
+++ b/src/com/yetanalytics/dave/ui/views/workbook/question/visualization.cljs
@@ -71,8 +71,7 @@
    [:div.cardtitle
     "Visualization"]
    [:h4 title]
-   [display workbook-id question-id id
-    :vega-override {:width 200}]
+   [display workbook-id question-id id]
    [:a {:href (str "#/workbooks/" workbook-id
                    "/questions/" question-id
                    "/visualizations/" id)}

--- a/src/com/yetanalytics/dave/vis/bar.cljc
+++ b/src/com/yetanalytics/dave/vis/bar.cljc
@@ -11,6 +11,7 @@
      :labelAlign "left"}
     {:orient "left", :scale "yscale"}],
    :width 500,
+   :height 200,
    :autosize "fit"
    :scales
    [{:name "xscale",
@@ -74,7 +75,6 @@
       {:events "rect:mouseout", :update "{}"}]}
     {:name "bar_color"
      :value "steelblue"}],
-   :height 200,
    :legends [{:fill "color"}]
    :data
    [{:name "table",

--- a/src/com/yetanalytics/dave/vis/line.cljc
+++ b/src/com/yetanalytics/dave/vis/line.cljc
@@ -6,6 +6,7 @@
   "Basic Vega Line chart with grouping."
   {:axes [{:orient "bottom", :scale "x"} {:orient "left", :scale "y"}],
    :width 500,
+   :height 200,
    :autosize "fit"
    :scales
    [{:name "x",
@@ -54,7 +55,6 @@
        "step"
        "step-after"
        "step-before"]}}],
-   :height 200,
    :data
    [{:name "table",
      :values

--- a/src/com/yetanalytics/dave/vis/pie.cljc
+++ b/src/com/yetanalytics/dave/vis/pie.cljc
@@ -6,7 +6,7 @@
   {:$schema "https://vega.github.io/schema/vega/v4.json",
    :width 400,
    :height 400,
-   :autosize "pad"
+   :autosize "fit-x"
    :signals
    [{:name "startAngle", :value 0}
     {:name "endAngle", :value 6.29}

--- a/src/com/yetanalytics/dave/vis/scatter.cljc
+++ b/src/com/yetanalytics/dave/vis/scatter.cljc
@@ -6,6 +6,7 @@
   "Basic Vega Scatter chart with grouping."
   {:axes [{:orient "bottom", :scale "x"} {:orient "left", :scale "y"}],
    :width 500,
+   :height 200,
    :autosize "fit"
    :scales
    [{:name "x",
@@ -56,7 +57,6 @@
        "step-after"
        "step-before"]}}],
    :legends [{:fill "color"}]
-   :height 200,
    :data
    [{:name "table",
      :values


### PR DESCRIPTION
Attempt to bring a little more sanity to Vega chart rendering.

Before, vega charts would ignore their internally set width and height, and they were sized purely based on the container element. This worked OK for w:h where w>h, but caused all kinds of strange formatting and overflow when used with a naturally square vis, like the pie chart.

Now, the process is more nuanced. At mount the vis component checks the height and width in the vis spec, if the height and width match, it uses them directly as the viewbox size. If not, it proceeds with getting the dimensions of the container and using these as the viewbox. This has the end effect of naturally displaying rectangular and square visualizations.