### PR TITLE
Vega x-axis labels

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -7,7 +7,7 @@
         {:git/url "https://github.com/yetanalytics/xapi-schema.git"
          :sha "e2c517e7adcedc7f3012b90bce274e2c33cdbcc1"}
         com.cognitect/transit-cljs {:mvn/version "0.8.256"}
-        cljsjs/vega {:mvn/version "4.3.0-0"}
+        cljsjs/vega {:mvn/version "5.3.2-0"}
         cljs-http {:mvn/version "0.1.45"}
         clj-http {:mvn/version "3.9.1"}
         com.andrewmcveigh/cljs-time {:mvn/version "0.5.2"}

--- a/src/com/yetanalytics/dave/vis/bar.cljc
+++ b/src/com/yetanalytics/dave/vis/bar.cljc
@@ -8,7 +8,11 @@
    [{:orient "bottom", :scale "xscale"
      :tickSize 0 :labelPadding 4 :zindex 1
      :labelAngle 60
-     :labelAlign "left"}
+     :labelAlign "left"
+     :labelLimit 112
+     :labelOverlap true
+     :labelSeparation -50
+     }
     {:orient "left", :scale "yscale"}],
    :width 500,
    :height 200,

--- a/src/com/yetanalytics/dave/vis/line.cljc
+++ b/src/com/yetanalytics/dave/vis/line.cljc
@@ -4,7 +4,13 @@
 
 (def base
   "Basic Vega Line chart with grouping."
-  {:axes [{:orient "bottom", :scale "x"} {:orient "left", :scale "y"}],
+  {:axes [{:orient "bottom", :scale "x"
+           :labelAngle 60
+           :labelAlign "left"
+           :labelLimit 112
+           :labelOverlap true
+           :labelSeparation -35}
+          {:orient "left", :scale "y"}],
    :width 500,
    :height 200,
    :autosize "fit"

--- a/src/com/yetanalytics/dave/vis/scatter.cljc
+++ b/src/com/yetanalytics/dave/vis/scatter.cljc
@@ -4,7 +4,13 @@
 
 (def base
   "Basic Vega Scatter chart with grouping."
-  {:axes [{:orient "bottom", :scale "x"} {:orient "left", :scale "y"}],
+  {:axes [{:orient "bottom", :scale "x"
+           :labelAngle 60
+           :labelAlign "left"
+           :labelLimit 112
+           :labelOverlap true
+           :labelSeparation -35}
+          {:orient "left", :scale "y"}],
    :width 500,
    :height 200,
    :autosize "fit"


### PR DESCRIPTION
* Update to vega 5.3.2
* For all x-axis labels (on line, time-line, bar, scatter, time-scatter):
  * Aligned left
  * Angled 60 degrees
  * Limited to 112px before elision
  * Overlap control turned on with pretty dense tolerance