### PR TITLE
148 vega tooltip bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This changelog!
 - Makefile for easier building w/o clojure syntax
 - CI via travis.org
+- `vega-tooltip` plugin for Vega renderer
 
 ### Changed
 - Changes to the Wizard navigation footer and other DAVE related buttons
@@ -16,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 ### Fixed
+- Tooltips now display properly
 
 ## [0.0.2] - 2019-05-31
 ### Added

--- a/deps.edn
+++ b/deps.edn
@@ -7,7 +7,8 @@
         {:git/url "https://github.com/yetanalytics/xapi-schema.git"
          :sha "e2c517e7adcedc7f3012b90bce274e2c33cdbcc1"}
         com.cognitect/transit-cljs {:mvn/version "0.8.256"}
-        cljsjs/vega {:mvn/version "5.3.2-0"}
+        cljsjs/vega {:mvn/version "5.3.4-0"}
+        cljsjs/vega-tooltip {:mvn/version "0.17.0-0"}
         cljs-http {:mvn/version "0.1.45"}
         clj-http {:mvn/version "3.9.1"}
         com.andrewmcveigh/cljs-time {:mvn/version "0.5.2"}

--- a/src/com/yetanalytics/dave/ui/views/vega.cljs
+++ b/src/com/yetanalytics/dave/ui/views/vega.cljs
@@ -17,6 +17,7 @@
   ]"
   (:require
    [cljsjs.vega]
+   [cljsjs.vega-tooltip]
    [reagent.core :as r]
    [reagent.ratom :as ratom]
    [re-frame.core :refer [dispatch subscribe]]
@@ -235,12 +236,14 @@
                    [el-width
                     el-height])
         runtime (.parse js/vega (clj->js spec))
+        tooltip-handler (js/vegaTooltip.Handler.)
         chart (-> (js/vega.View. runtime)
                   (.logLevel (s/conform ::log-level
                                         log-level))
 
                   (.width width)
                   (.height height)
+                  (.tooltip (.-call tooltip-handler))
                   (.renderer renderer)
                   (.initialize el)
                   (cond-> hover? .hover))]


### PR DESCRIPTION
Fixes #148 

As it turns out it wasn't MDC doing it, we were just using the default tooltips which leverage the browser and don't look very good. SO, this PR installs the `vega-tooltip` plugin and we get immediate tooltips with nice styling.