### PR TITLE
create indexed attrs for inst rep of timestamp + stored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.4] - Unreleased
+### Added
+- Statement `timestamp` and `stored` are parsed and indexed as `:statement/timestamp-inst` and `:statement/stored-inst`
+
+### Removed
+- Timestamp strings are no longer indexed
+
 ## [0.0.3] - 2020-02-24
 ### Added
 - DAVE Analysis entity

--- a/src/com/yetanalytics/dave/datalog.cljc
+++ b/src/com/yetanalytics/dave/datalog.cljc
@@ -220,6 +220,9 @@
     (assoc x :anon-group/member (pr-str (:group/member x)))
     x))
 
+;; TODO: currently, timestamps cannot be compared with clojure.core/< and
+;; friends on JVM clojure
+
 (defn index-timestamps
   [{timestamp :statement/timestamp
     stored    :statement/stored

--- a/src/com/yetanalytics/dave/datalog/builtins.cljc
+++ b/src/com/yetanalytics/dave/datalog/builtins.cljc
@@ -1,4 +1,5 @@
 (ns com.yetanalytics.dave.datalog.builtins
+  (:require [com.yetanalytics.dave.datalog.builtins.time :as t])
   #?(:clj (:import [java.util Date TimeZone]
                    [java.time
                     Instant
@@ -61,4 +62,5 @@
 
 (def builtins
   [[:timestamp->unix timestamp->unix]
-  [:math-transform math-transform]])
+   [:math-transform math-transform]
+   [:time/format t/tformat]])

--- a/src/com/yetanalytics/dave/datalog/builtins/time.cljc
+++ b/src/com/yetanalytics/dave/datalog/builtins/time.cljc
@@ -1,0 +1,32 @@
+(ns com.yetanalytics.dave.datalog.builtins.time
+  "Built-ins for time"
+  (:require [#?(:clj clj-time.core
+                :cljs cljs-time.core) :as t]
+            [#?(:clj clj-time.format
+                :cljs cljs-time.format) :as tf]
+            [#?(:clj clj-time.coerce
+                :cljs cljs-time.coerce) :as tc]))
+
+;; TODO: replace with more modern time APIs... cljc.java-time + Tick?
+
+(defn tformat
+  [fmt-str date]
+  (try (tf/unparse
+        (tf/formatter fmt-str)
+        (tc/to-date-time date))
+       (catch #?(:clj Exception
+                 :cljs js/Error) e
+         (throw (ex-info "Timestamp Format Error!"
+                         {:type ::date-format-error}
+                         e)))))
+
+(comment
+
+  (tformat "e"
+          #inst "2018-12-19T13:58:29.000-00:00")
+
+
+  (tf/unparse
+   (tf/formatter (tf/formatter "yyyy-MM-dd'T'HH:mm:ss.SSSZZ"))
+   (tc/to-date-time #inst "2018-12-19T13:58:29.000-00:00"))
+  )

--- a/src/com/yetanalytics/dave/datalog/rules.cljc
+++ b/src/com/yetanalytics/dave/datalog/rules.cljc
@@ -9,4 +9,7 @@
      [$fn :math-transform ?f]
      [(?f ?format ?args) ?result]]
     [[->x-y-datum ?x ?y ?datum]
-     [(array-map :x ?x :y ?y) ?datum]]])
+     [(array-map :x ?x :y ?y) ?datum]]
+    [[time-format ?fmt ?t ?t-str]
+     [$fn :time/format ?f]
+     [(?f ?fmt ?t) ?t-str]]])

--- a/src/com/yetanalytics/dave/datalog/schema.cljc
+++ b/src/com/yetanalytics/dave/datalog/schema.cljc
@@ -71,8 +71,11 @@
    :sub-statement/object          {:db/valueType :db.type/ref},
 
    :statement/stored              {:db/index true},
+   :statement/stored-inst         {:db/index true},
    :statement/timestamp           {:db/index true},
+   :statement/timestamp-inst      {:db/index true},
    :sub-statement/timestamp       {:db/index true},
+   :sub-statement/timestamp-inst  {:db/index true},
    :statement/verb                {:db/valueType :db.type/ref},
    :sub-statement/verb            {:db/valueType :db.type/ref},
    :statement-ref/id              {:db/unique :db.unique/identity},

--- a/src/com/yetanalytics/dave/datalog/schema.cljc
+++ b/src/com/yetanalytics/dave/datalog/schema.cljc
@@ -70,11 +70,11 @@
    :statement/object              {:db/valueType :db.type/ref},
    :sub-statement/object          {:db/valueType :db.type/ref},
 
-   :statement/stored              {:db/index true},
+   ; :statement/stored              {:db/index true}, ;; Don't index if we are duping
    :statement/stored-inst         {:db/index true},
-   :statement/timestamp           {:db/index true},
+   ; :statement/timestamp           {:db/index true},
    :statement/timestamp-inst      {:db/index true},
-   :sub-statement/timestamp       {:db/index true},
+   ; :sub-statement/timestamp       {:db/index true},
    :sub-statement/timestamp-inst  {:db/index true},
    :statement/verb                {:db/valueType :db.type/ref},
    :sub-statement/verb            {:db/valueType :db.type/ref},

--- a/test/com/yetanalytics/dave/datalog_test.cljc
+++ b/test/com/yetanalytics/dave/datalog_test.cljc
@@ -34,7 +34,7 @@
     (testing "static statements"
       (let [db (d/db-with (d/init-db [] schema/xapi) tx)]
         (is (d/db? db))
-        (is (= 2368 (count (d/datoms db :eavt))))
+        (is (= 2816 (count (d/datoms db :eavt))))
         (is (= 224
                  (d/q '[:find (count-distinct ?s) .
                         :where


### PR DESCRIPTION
In order to make timestamps/stored useful in queries, we should parse and index them.
Also we need to expose a conversion facility in our query functions!