### PR TITLE
consistent hostnames

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,8 @@
                               :exclusions [org.clojure/clojurescript
                                            reagent]}
         datascript {:mvn/version "0.18.8"}
-        datascript-transit {:mvn/version "0.3.0"}}
+        datascript-transit {:mvn/version "0.3.0"}
+        lambdaisland/uri {:mvn/version "1.2.1"}}
  :paths ["src" "resources"]
  :aliases {:fig {:extra-deps
                  {com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}

--- a/src/com/yetanalytics/dave/ui/app/workbook/data.cljs
+++ b/src/com/yetanalytics/dave/ui/app/workbook/data.cljs
@@ -210,7 +210,7 @@
    ;; Do an authenticated HEAD request
    {:http/request
     {:request {:url (str (:endpoint lrs-spec)
-                         "/xapi/statements?limit=1")
+                         "/statements?limit=1")
                :headers {"X-Experience-Api-Version" "1.0.3"}
                :basic-auth (select-keys
                             (:auth lrs-spec)

--- a/src/com/yetanalytics/dave/ui/app/workbook/data/lrs.cljs
+++ b/src/com/yetanalytics/dave/ui/app/workbook/data/lrs.cljs
@@ -3,7 +3,8 @@
   (:require [re-frame.core :as re-frame]
             [com.yetanalytics.dave.workbook.data.state :as state]
             [com.yetanalytics.dave.workbook.data.lrs.client :as client]
-            [com.yetanalytics.dave.util.log :as log]))
+            [com.yetanalytics.dave.util.log :as log]
+            [lambdaisland.uri :refer [join]]))
 
 ;; ingress
 (re-frame/reg-event-fx
@@ -36,8 +37,7 @@
          ?since (get-in state [:stored-domain 1])]
      (log/debugf "Query lrs: %s state: %s" lrs-state state)
      {:http/request
-      {:request {:url (str endpoint
-                           "/xapi/statements")
+      {:request {:url (str endpoint "/statements")
                  :headers {"X-Experience-Api-Version" "1.0.3"}
                  :basic-auth (select-keys
                               auth
@@ -185,8 +185,7 @@
    (log/debugf "Continue state: %s more: %s"
              state more-link)
    {:http/request
-    {:request {:url (str endpoint
-                         more-link)
+    {:request {:url (join (str endpoint "/") (or more-link "statements"))
                :headers {"X-Experience-Api-Version" "1.0.3"}
                :basic-auth (select-keys
                             auth


### PR DESCRIPTION
changed hostname format to expect the "/xapi" like datasim and also the play nice with various "more" link formats